### PR TITLE
Handle partial response from enumerateDeivce

### DIFF
--- a/src/navigator/enumerateDevices.ts
+++ b/src/navigator/enumerateDevices.ts
@@ -15,9 +15,12 @@ export const enumerateDevices = async (
 
   let mediaDeviceInfos: MediaDeviceInfo[] = await navigator.mediaDevices.enumerateDevices();
 
+  const videoNotGranted = mediaDeviceInfos.filter(isVideo).some(isNotGranted);
+  const audioNotGranted = mediaDeviceInfos.filter(isAudio).some(isNotGranted);
+
   const constraints = {
-    video: booleanVideo && mediaDeviceInfos.filter(isVideo).some(isNotGranted) && objVideo,
-    audio: booleanAudio && mediaDeviceInfos.filter(isAudio).some(isNotGranted) && objAudio,
+    video: booleanVideo && videoNotGranted && objVideo,
+    audio: booleanAudio && audioNotGranted && objAudio,
   };
 
   let audioError: string | null = null;
@@ -35,8 +38,8 @@ export const enumerateDevices = async (
     }
   } catch (error: any) {
     // https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia#exceptions
-    videoError = booleanVideo ? error.name : null;
-    audioError = booleanAudio ? error.name : null;
+    videoError = booleanVideo && videoNotGranted ? error.name : null;
+    audioError = booleanAudio && audioNotGranted ? error.name : null;
   }
 
   return {

--- a/src/navigator/types.ts
+++ b/src/navigator/types.ts
@@ -1,6 +1,6 @@
 export type DeviceReturnType =
   | { type: "OK"; devices: MediaDeviceInfo[] }
-  | { type: "Error"; message: string | null }
+  | { type: "Error"; name: string | null }
   | { type: "Not requested" };
 
 export type EnumerateDevices = {

--- a/src/navigator/useEnumerateDevices.tsx
+++ b/src/navigator/useEnumerateDevices.tsx
@@ -33,9 +33,12 @@ export const useEnumerateDevices = (
 
     let mediaDeviceInfos: MediaDeviceInfo[] = await navigator.mediaDevices.enumerateDevices();
 
+    const videoNotGranted = mediaDeviceInfos.filter(isVideo).some(isNotGranted);
+    const audioNotGranted = mediaDeviceInfos.filter(isAudio).some(isNotGranted);
+
     const constraints = {
-      video: booleanVideo && mediaDeviceInfos.filter(isVideo).some(isNotGranted) && objVideo,
-      audio: booleanAudio && mediaDeviceInfos.filter(isAudio).some(isNotGranted) && objAudio,
+      video: booleanVideo && videoNotGranted && objVideo,
+      audio: booleanAudio && audioNotGranted && objAudio,
     };
 
     let audioError: string | null = null;
@@ -53,8 +56,8 @@ export const useEnumerateDevices = (
       }
     } catch (error: any) {
       // https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia#exceptions
-      videoError = booleanVideo ? error.name : null;
-      audioError = booleanAudio ? error.name : null;
+      videoError = booleanVideo && videoNotGranted ? error.name : null;
+      audioError = booleanAudio && audioNotGranted ? error.name : null;
     }
 
     setState({

--- a/src/navigator/utils.ts
+++ b/src/navigator/utils.ts
@@ -31,7 +31,7 @@ export const prepareReturn = (
   permissionError: string | null
 ): DeviceReturnType => {
   if (!isInterested) return { type: "Not requested" };
-  if (permissionError) return { type: "Error", message: permissionError };
+  if (permissionError) return { type: "Error", name: permissionError };
   return { type: "OK", devices: mediaDeviceInfo.filter(isGranted) };
 };
 


### PR DESCRIPTION
This allows us to get at least some devices. Before this change `useEnumerateDevices` returns an error for both Audio and Video